### PR TITLE
roberts parralel + tests

### DIFF
--- a/include/algo.hpp
+++ b/include/algo.hpp
@@ -19,3 +19,7 @@ void prewitt_x_parallel_vec_wrap(const Mat& src, Mat& dst);
 void prewitt_x_parallel_vec_wrap2(const Mat& src, Mat& dst);
 
 void roberts_reference(const cv::Mat& src, cv::Mat& dst);
+
+void roberts_reference(const cv::Mat& src, cv::Mat& dst);
+
+void roberts_parralel(const cv::Mat& src, cv::Mat& dst);

--- a/perf/perf_roberts.cpp
+++ b/perf/perf_roberts.cpp
@@ -1,0 +1,25 @@
+#include <opencv2/ts.hpp>
+
+#include "algo.hpp"
+
+PERF_TEST(Roberts, ref)
+{
+    cv::Mat src(1080, 1920, CV_8UC1), dst;
+
+    PERF_SAMPLE_BEGIN()
+        roberts_reference(src, dst);
+    PERF_SAMPLE_END()
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST(Roberts, parallel)
+{
+    cv::Mat src(1080, 1920, CV_8UC1), dst;
+
+    PERF_SAMPLE_BEGIN()
+        roberts_parralel(src, dst);
+    PERF_SAMPLE_END()
+
+    SANITY_CHECK_NOTHING();
+}

--- a/src/roberts.cpp
+++ b/src/roberts.cpp
@@ -12,3 +12,19 @@ void roberts_reference(const cv::Mat& src, cv::Mat& dst) {
             dst.at<uint32_t>(y, x) = dx * dx + dy * dy;
         }
 }
+
+void roberts_parralel(const cv::Mat& src, cv::Mat& dst) {
+    CV_Assert(src.type() == CV_8UC1);
+    Mat bsrc;
+    copyMakeBorder(src, bsrc, 1, 1, 1, 1, BORDER_REPLICATE);
+    dst.create(src.size(), CV_32SC1);
+    parallel_for_(Range(0, dst.rows), [&](const Range& range) {
+        for (int y = range.start; y < range.end; ++y) {
+            for (int x = 0; x < dst.cols; ++x) {
+                int dx = bsrc.at<uchar>(y, x) - bsrc.at<uchar>(y + 1, x + 1);
+                int dy = bsrc.at<uchar>(y, x + 1) - bsrc.at<uchar>(y + 1, x);
+                dst.at<uint32_t>(y, x) = dx * dx + dy * dy;
+            }
+        }
+    });
+}

--- a/test/test_roberts.cpp
+++ b/test/test_roberts.cpp
@@ -1,0 +1,17 @@
+#include <opencv2/ts.hpp>
+
+#include "algo.hpp"
+
+typedef testing::TestWithParam<Size> Roberts;
+TEST_P(Roberts, parallel)
+{
+    cv::Mat src(GetParam(), CV_8UC1), ref, dst;
+    randu(src, 0, 255);
+
+    roberts_reference(src, ref);
+    roberts_parralel(src, dst);
+
+    EXPECT_EQ(countNonZero(ref != dst), 0);
+}
+
+INSTANTIATE_TEST_CASE_P(/**/, Roberts, testing::Values(TYPICAL_MAT_SIZES));


### PR DESCRIPTION
```
[----------] 2 tests from Roberts
[ RUN      ] Roberts.ref
[ PERFSTAT ]    (samples=25   mean=3.09   median=3.05   min=3.02   stddev=0.08 (2.5%))
[       OK ] Roberts.ref (79 ms)
[ RUN      ] Roberts.parallel
[ PERFSTAT ]    (samples=13   mean=1.66   median=1.65   min=1.63   stddev=0.04 (2.2%))
[       OK ] Roberts.parallel (22 ms)
[----------] 2 tests from Roberts (101 ms total)
```