### PR TITLE
Roberts - parallel & vector_wrap + tests

### DIFF
--- a/include/algo.hpp
+++ b/include/algo.hpp
@@ -19,3 +19,7 @@ void prewitt_x_parallel_vec_wrap(const Mat& src, Mat& dst);
 void prewitt_x_parallel_vec_wrap2(const Mat& src, Mat& dst);
 
 void roberts_reference(const cv::Mat& src, cv::Mat& dst);
+
+void roberts_parallel(const cv::Mat& src, cv::Mat& dst);
+
+void roberts_parallel_vec_wrap(const Mat& src, Mat& dst);

--- a/perf/perf_roberts.cpp
+++ b/perf/perf_roberts.cpp
@@ -1,0 +1,36 @@
+#include <opencv2/ts.hpp>
+
+#include "algo.hpp"
+
+PERF_TEST(Roberts, ref)
+{
+    cv::Mat src(1080, 1920, CV_8UC1), dst;
+
+    PERF_SAMPLE_BEGIN()
+        roberts_reference(src, dst);
+    PERF_SAMPLE_END()
+
+        SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST(Roberts, parallel)
+{
+    cv::Mat src(1080, 1920, CV_8UC1), dst;
+
+    PERF_SAMPLE_BEGIN()
+        roberts_parallel(src, dst);
+    PERF_SAMPLE_END()
+
+        SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST(Roberts, parallel_vec_wrap)
+{
+    cv::Mat src(1080, 1920, CV_8UC1), dst;
+
+    PERF_SAMPLE_BEGIN()
+        roberts_parallel_vec_wrap(src, dst);
+    PERF_SAMPLE_END()
+
+        SANITY_CHECK_NOTHING();
+}

--- a/src/roberts.cpp
+++ b/src/roberts.cpp
@@ -5,25 +5,25 @@ void roberts_reference(const cv::Mat& src, cv::Mat& dst) {
     CV_Assert(src.type() == CV_8UC1);
     Mat bsrc;
     copyMakeBorder(src, bsrc, 1, 1, 1, 1, BORDER_REPLICATE);
-    dst.create(src.size(), CV_32SC1);
+    dst.create(src.size(), CV_16SC1);
     for (int y = 0; y < dst.rows; ++y)
         for (int x = 0; x < dst.cols; ++x) {
             int dx = bsrc.at<uchar>(y, x) - bsrc.at<uchar>(y + 1, x + 1);
             int dy = bsrc.at<uchar>(y, x + 1) - bsrc.at<uchar>(y + 1, x);
-            dst.at<uint32_t>(y, x) = dx * dx + dy * dy;
+            dst.at<int16_t>(y, x) = dx * dx + dy * dy;
         }
 }
 
 void roberts_parallel(const Mat& src, Mat& dst) {
     Mat bsrc;
     copyMakeBorder(src, bsrc, 1, 1, 1, 1, BORDER_REPLICATE);
-    dst.create(src.size(), CV_32SC1);
+    dst.create(src.size(), CV_16SC1);
     parallel_for_(Range(0, src.rows), [&](const Range& range) {
         for (int y = range.start; y < range.end; ++y)
             for (int x = 0; x < dst.cols; ++x) {
                 int dx = bsrc.at<uchar>(y, x) - bsrc.at<uchar>(y + 1, x + 1);
                 int dy = bsrc.at<uchar>(y, x + 1) - bsrc.at<uchar>(y + 1, x);
-                dst.at<uint32_t>(y, x) = dx * dx + dy * dy;
+                dst.at<int16_t>(y, x) = dx * dx + dy * dy;
             }
     });
 }
@@ -40,7 +40,7 @@ void roberts_parallel_vec_wrap(const Mat& src, Mat& dst) {
             const uint8_t* psrc1 = bsrc.ptr(y + 1);
             int16_t* pdst = dst.ptr<int16_t>(y);
             int x = 0;
-            for (; x <= dst.cols - v_int16::nlanes; x += v_int16::nlanes) {
+            for (; x <= dst.cols - v_uint16::nlanes; x += v_uint16::nlanes) {
                 v_int16 vdx = v_reinterpret_as_s16(vx_load_expand(psrc0 + x)) -
                     v_reinterpret_as_s16(vx_load_expand(psrc1 + x + 1));
                 v_int16 vdy = v_reinterpret_as_s16(vx_load_expand(psrc0 + x + 1)) -

--- a/src/roberts.cpp
+++ b/src/roberts.cpp
@@ -1,4 +1,5 @@
 #include "algo.hpp"
+#include <iostream>
 
 void roberts_reference(const cv::Mat& src, cv::Mat& dst) {
     CV_Assert(src.type() == CV_8UC1);
@@ -11,4 +12,47 @@ void roberts_reference(const cv::Mat& src, cv::Mat& dst) {
             int dy = bsrc.at<uchar>(y, x + 1) - bsrc.at<uchar>(y + 1, x);
             dst.at<uint32_t>(y, x) = dx * dx + dy * dy;
         }
+}
+
+void roberts_parallel(const Mat& src, Mat& dst) {
+    Mat bsrc;
+    copyMakeBorder(src, bsrc, 1, 1, 1, 1, BORDER_REPLICATE);
+    dst.create(src.size(), CV_32SC1);
+    parallel_for_(Range(0, src.rows), [&](const Range& range) {
+        for (int y = range.start; y < range.end; ++y)
+            for (int x = 0; x < dst.cols; ++x) {
+                int dx = bsrc.at<uchar>(y, x) - bsrc.at<uchar>(y + 1, x + 1);
+                int dy = bsrc.at<uchar>(y, x + 1) - bsrc.at<uchar>(y + 1, x);
+                dst.at<uint32_t>(y, x) = dx * dx + dy * dy;
+            }
+    });
+}
+
+#include <opencv2/core/hal/intrin.hpp>
+
+void roberts_parallel_vec_wrap(const Mat& src, Mat& dst) {
+    Mat bsrc;
+    copyMakeBorder(src, bsrc, 1, 1, 1, 1, BORDER_REPLICATE);
+    dst.create(src.size(), CV_32SC1);
+    parallel_for_(Range(0, src.rows), [&](const Range& range) {
+        for (int y = range.start; y < range.end; ++y) {
+            const uint8_t* psrc0 = bsrc.ptr(y);
+            const uint8_t* psrc1 = bsrc.ptr(y + 1);
+            uint8_t* pdst = dst.ptr(y);
+            int x = 0;
+            for (; x <= dst.cols - v_uint8::nlanes; x += v_uint8::nlanes) {
+                v_uint8 res = v_add_wrap(
+                    v_mul_wrap(v_sub_wrap(vx_load(psrc0 + x), vx_load(psrc1 + x + 1)), 
+                               v_sub_wrap(vx_load(psrc0 + x), vx_load(psrc1 + x + 1))),
+                    v_mul_wrap(v_sub_wrap(vx_load(psrc0 + x + 1), vx_load(psrc1 + x)),
+                               v_sub_wrap(vx_load(psrc0 + x + 1), vx_load(psrc1 + x)))
+                );
+                v_store(pdst + x, res);
+            }
+            for (; x < dst.cols; ++x) {
+                pdst[x] = (psrc0[x] - psrc1[x + 1]) * (psrc0[x] - psrc1[x + 1]) +
+                    (psrc0[x + 1] - psrc1[x]) * (psrc0[x + 1] - psrc1[x]);
+            }
+        }
+    });
 }

--- a/test/test_roberts.cpp
+++ b/test/test_roberts.cpp
@@ -17,7 +17,7 @@ TEST_P(Roberts, parallel)
 TEST_P(Roberts, parallel_vec_wrap)
 {
     cv::Mat src(GetParam(), CV_8UC1), ref, dst;
-    randu(src, 0, 255);
+    randu(src, 0, 127);
 
     roberts_reference(src, ref);
     roberts_parallel_vec_wrap(src, dst);

--- a/test/test_roberts.cpp
+++ b/test/test_roberts.cpp
@@ -1,0 +1,28 @@
+#include <opencv2/ts.hpp>
+
+#include "algo.hpp"
+
+typedef testing::TestWithParam<Size> Roberts;
+TEST_P(Roberts, parallel)
+{
+    cv::Mat src(GetParam(), CV_8UC1), ref, dst;
+    randu(src, 0, 255);
+
+    roberts_reference(src, ref);
+    roberts_parallel(src, dst);
+
+    EXPECT_EQ(countNonZero(ref != dst), 0);
+}
+
+TEST_P(Roberts, parallel_vec_wrap)
+{
+    cv::Mat src(GetParam(), CV_8UC1), ref, dst;
+    randu(src, 0, 255);
+
+    prewitt_x(src, ref);
+    prewitt_x_parallel_vec_wrap(src, dst);
+
+    EXPECT_EQ(countNonZero(ref != dst), 0);
+}
+
+INSTANTIATE_TEST_CASE_P(/**/, Roberts, testing::Values(TYPICAL_MAT_SIZES));

--- a/test/test_roberts.cpp
+++ b/test/test_roberts.cpp
@@ -19,8 +19,8 @@ TEST_P(Roberts, parallel_vec_wrap)
     cv::Mat src(GetParam(), CV_8UC1), ref, dst;
     randu(src, 0, 255);
 
-    prewitt_x(src, ref);
-    prewitt_x_parallel_vec_wrap(src, dst);
+    roberts_reference(src, ref);
+    roberts_parallel_vec_wrap(src, dst);
 
     EXPECT_EQ(countNonZero(ref != dst), 0);
 }


### PR DESCRIPTION
```
[----------] 3 tests from Roberts
[ RUN      ] Roberts.ref
[ PERFSTAT ]    (samples=100   mean=9.08   median=8.48   min=5.85   stddev=2.41 (26.5%))
[       OK ] Roberts.ref (994 ms)
[ RUN      ] Roberts.parallel
[ PERFSTAT ]    (samples=100   mean=7.22   median=6.83   min=4.81   stddev=1.96 (27.1%))
[       OK ] Roberts.parallel (826 ms)
[ RUN      ] Roberts.parallel_vec_wrap
[ PERFSTAT ]    (samples=100   mean=2.02   median=1.62   min=1.37   stddev=0.87 (43.0%))
[       OK ] Roberts.parallel_vec_wrap (239 ms)
[----------] 3 tests from Roberts (2080 ms total)
```